### PR TITLE
Utvidet logging av synkrone meldinger

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -170,6 +170,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                 }
                 NotifyMessageProcessingReady(message, incomingMessage);
                 ServiceBusCore.RemoveProcessedMessageFromQueue(Logger, message);
+                Logger.LogRemoveMessageFromQueueNormal(message, QueueName);
                 NotifyMessageProcessingCompleted(incomingMessage);
                 Logger.LogEndReceive(QueueType, incomingMessage);
                 return incomingMessage;

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -402,7 +402,6 @@ namespace Helsenorge.Messaging.ServiceBus
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
 
-            logger.LogRemoveMessageFromQueueNormal(message.MessageId);
             message.Complete();
         }
         /// <summary>

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusLoggingExtensions.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusLoggingExtensions.cs
@@ -26,7 +26,7 @@ namespace Helsenorge.Messaging.ServiceBus
         private static readonly Action<ILogger, string, int, int, string, Exception> AfterFactoryPoolCreateMessage;
 
         private static readonly Action<ILogger, string, Exception> ExternalReportedError;
-        private static readonly Action<ILogger, string, Exception> RemoveMessageFromQueueNormal;
+        private static readonly Action<ILogger, string, int, string, string, Exception> RemoveMessageFromQueueNormal;
         private static readonly Action<ILogger, string, Exception> RemoveMessageFromQueueError;
 
         public static void LogStartReceive(this ILogger logger, QueueType queueType, IncomingMessage message)
@@ -97,9 +97,9 @@ namespace Helsenorge.Messaging.ServiceBus
             ExternalReportedError(logger, message, null);
         }
 
-        public static void LogRemoveMessageFromQueueNormal(this ILogger logger, string id)
+        public static void LogRemoveMessageFromQueueNormal(this ILogger logger, IMessagingMessage message, string queueName)
         {
-            RemoveMessageFromQueueNormal(logger, id, null);
+            RemoveMessageFromQueueNormal(logger, message.MessageId, message.FromHerId, queueName, message.CorrelationId, null);
         }
         public static void LogRemoveMessageFromQueueError(this ILogger logger, string id)
         {
@@ -138,10 +138,10 @@ namespace Helsenorge.Messaging.ServiceBus
                 EventIds.ExternalReportedError,
                 "{Message}");
 
-            RemoveMessageFromQueueNormal = LoggerMessage.Define<string>(
+            RemoveMessageFromQueueNormal = LoggerMessage.Define<string, int, string, string>(
                 LogLevel.Information,
                 EventIds.RemoveMessageFromQueue,
-                "Removing processed message {MessageId} from queue");
+                "Removing processed message {MessageId} from Herid {herId} from queue {queueName}. Correlation = {correlationId}");
 
             RemoveMessageFromQueueError = LoggerMessage.Define<string>(
                 LogLevel.Information,

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/SynchronousSendTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/SynchronousSendTests.cs
@@ -51,7 +51,11 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Senders
             MockFactory.Helsenorge.SynchronousReply.Messages.Add(mockMessage);
 
             var response = RunAndHandleException(Client.SendAndWaitAsync(Logger, message));
-            
+
+            var logProcessedMessage = MockLoggerProvider.Entries.Where(l => l.LogLevel == LogLevel.Information
+                       && l.Message.Contains($"Removing processed message { mockMessage.MessageId} from Herid { MockFactory.OtherHerId } from queue { MockFactory.Helsenorge.SynchronousReply.Name}. Correlation = { message.MessageId }"));
+            Assert.AreEqual(1, logProcessedMessage.Count());
+
             var logEntry = MockLoggerProvider.Entries.Where(l => l.LogLevel == LogLevel.Information
                        && l.Message.Contains("ResponseTime")
                        && l.Message.EndsWith(" ms"));


### PR DESCRIPTION
Lagt til logging av HerId, navn på kø og korrelasjon Id ved prosesserte meldinger. 

- Oppdatert test metode "Send_Synchronous_OK"
- Oppdatert logging extension LogRemoveMessageFromQueueNormal i ServiceBusLoggingExtensions

Se punkt 1 i Issue #79 